### PR TITLE
use `dev_tode` branch of GsDevKit_home to get `dev` branch of tODE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ os:
 
 env:
   - GSCI_CLIENTS="Pharo-5.0"
+  - GSCI_DEVKIT_BRANCH="dev_tode"
 
 smalltalk:
   - GemStone-3.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ os:
   - linux
 
 env:
-  - GSCI_CLIENTS="Pharo-5.0"
-  - GSCI_DEVKIT_BRANCH="dev_tode"
+  - GSCI_CLIENTS="Pharo-5.0" GSCI_DEVKIT_BRANCH="dev_tode"
 
 smalltalk:
   - GemStone-3.3.0


### PR DESCRIPTION
You will also want to clear the travis-ci caches before integrating this pr ... the GemStone extent is cached which means that you could be using an older version of tODE .... clearing the cache will rebuild the extents with the latest code ... 

My build got [1 test failure](https://travis-ci.org/dalehenrich/gt4gemstone#L2511), while your build had [3 test errors](https://travis-ci.org/feenkcom/gt4gemstone/builds/186431499#L1694) so I assume that the using the dev branch of tode ([verified](https://travis-ci.org/dalehenrich/gt4gemstone#L500-L505)) makes a difference ...